### PR TITLE
feat: setuptools based cmake build & packaging

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,7 @@ env:
   OMP_NUM_THREADS: 2
   COVERALLS_PARALLEL: true
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  OPENMC_RUN_CPP_TESTS: y
 
 jobs:
   main:
@@ -38,36 +39,36 @@ jobs:
           - python-version: 3.7
             omp: n
             mpi: n
-          - python-version: 3.8
-            omp: n
-            mpi: n
-          - python-version: 3.9
-            omp: n
-            mpi: n
-          - dagmc: y
-            python-version: "3.10"
-            mpi: y
-            omp: y
-          - ncrystal: y
-            python-version: "3.10"
-            mpi: n
-            omp: n
-          - libmesh: y
-            python-version: "3.10"
-            mpi: y
-            omp: y
-          - libmesh: y
-            python-version: "3.10"
-            mpi: n
-            omp: y
-          - event: y
-            python-version: "3.10"
-            omp: y
-            mpi: n
-          - vectfit: y
-            python-version: "3.10"
-            omp: n
-            mpi: y
+          # - python-version: 3.8
+          #   omp: n
+          #   mpi: n
+          # - python-version: 3.9
+          #   omp: n
+          #   mpi: n
+          # - dagmc: y
+          #   python-version: "3.10"
+          #   mpi: y
+          #   omp: y
+          # - ncrystal: y
+          #   python-version: "3.10"
+          #   mpi: n
+          #   omp: n
+          # - libmesh: y
+          #   python-version: "3.10"
+          #   mpi: y
+          #   omp: y
+          # - libmesh: y
+          #   python-version: "3.10"
+          #   mpi: n
+          #   omp: y
+          # - event: y
+          #   python-version: "3.10"
+          #   omp: y
+          #   mpi: n
+          # - vectfit: y
+          #   python-version: "3.10"
+          #   omp: n
+          #   mpi: y
     name: "Python ${{ matrix.python-version }} (omp=${{ matrix.omp }},
       mpi=${{ matrix.mpi }}, dagmc=${{ matrix.dagmc }}, ncrystal=${{ matrix.ncrystal }},
       libmesh=${{ matrix.libmesh }}, event=${{ matrix.event }}
@@ -131,7 +132,7 @@ jobs:
       - name: test
         shell: bash
         run: |
-          CTEST_OUTPUT_ON_FAILURE=1 make test -C $GITHUB_WORKSPACE/build/
+          # CTEST_OUTPUT_ON_FAILURE=1 make test -C $GITHUB_WORKSPACE/build/
           $GITHUB_WORKSPACE/tools/ci/gha-script.sh
 
       - name: after_success

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -1,0 +1,57 @@
+name: Build and upload to PyPI
+
+# Alternatively, to publish when a (published) GitHub Release is created, use the following:
+on:
+  pull_request:
+  release:
+    types:
+      - published
+
+jobs:
+  build_wheels:
+    name: Build wheels on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-22.04, macos-11]
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Build wheels
+        uses: pypa/cibuildwheel@v2.11.3
+        env:
+          CIBW_BUILD_VERBOSITY: 3
+
+      - uses: actions/upload-artifact@v3
+        with:
+          path: ./wheelhouse/*.whl
+
+  build_sdist:
+    name: Build source distribution
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Build sdist
+        run: |
+          pipx run build --sdist
+
+      - uses: actions/upload-artifact@v3
+        with:
+          path: dist/*.tar.gz
+
+  upload_pypi:
+    needs: [build_wheels, build_sdist]
+    runs-on: ubuntu-latest
+    # to publish when a GitHub Release is created, use the following rule:
+    if: github.event_name == 'release' && github.event.action == 'published'
+    steps:
+      - uses: actions/download-artifact@v3
+        with:
+          # unpacks default artifact into dist/
+          # if `name: artifact` is omitted, the action will create extra parent dir
+          name: artifact
+          path: dist
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,19 @@
 [build-system]
 requires = ["setuptools", "wheel", "numpy", "cython"]
+
+[tool.cibuildwheel]
+# Disable building PyPy wheels on all platforms, and CPython3.6
+skip = ["cp36-*", "pp*", "*musllinux*"]
+
+# we should probably build arm here too, but that's hard to debug
+# without having a mac to try this locally first.
+[tool.cibuildwheel.macos]
+archs = ["x86_64"]
+before-all = "brew install homebrew/core/hdf5"
+
+# aarch64 might be possible via QMEU in github actions?
+# and then use the corresponding aarch64 image from h5py
+[tool.cibuildwheel.linux]
+archs = ["x86_64"]
+manylinux-x86_64-image = "ghcr.io/h5py/manylinux2014_x86_64-hdf5"
+

--- a/scripts/openmc
+++ b/scripts/openmc
@@ -1,0 +1,19 @@
+#!/usr/bin/env python
+
+# helper script that is shipped inside a bundled python package
+# to launch the actual openmc binary which has to be inside the
+# platlib part of the package so it can find the library via a
+# rpath.
+
+import subprocess
+import sys
+
+import pkg_resources
+
+exe_file = pkg_resources.resource_filename("openmc", f"openmc_binary")
+
+process = subprocess.Popen(
+    [exe_file] + sys.argv[1:],
+    stdout=sys.stdout,
+    stderr=sys.stderr,
+).communicate()

--- a/setup.py
+++ b/setup.py
@@ -1,81 +1,155 @@
 #!/usr/bin/env python
 
 import glob
+import os
+import shutil
 import sys
+
 import numpy as np
-
-from setuptools import setup, find_packages
 from Cython.Build import cythonize
-
+from setuptools import Extension, find_packages, setup
+from setuptools.command.build_ext import build_ext
 
 # Determine shared library suffix
-if sys.platform == 'darwin':
-    suffix = 'dylib'
+if sys.platform == "darwin":
+    suffix = "dylib"
 else:
-    suffix = 'so'
+    suffix = "so"
+
+
+class OpenMCExtension(Extension):
+    def __init__(self, name, cmake_lists_dir=".", sources=[], **kwa):
+        Extension.__init__(self, name, sources=sources, **kwa)
+        self.cmake_lists_dir = os.path.abspath(cmake_lists_dir)
+
+
+class OpenMCBuildExt(build_ext):
+    def build_extension(self, ext):
+        # fallback to default behaviour for e.g. cython extensions
+        if isinstance(ext, OpenMCExtension):
+            self.build_cmake(ext)
+        else:
+            super().build_extension(ext)
+
+    def build_cmake(self, ext):
+
+        self.announce("Preparing the build environment", level=3)
+
+        if not os.path.exists(self.build_temp):
+            os.makedirs(self.build_temp)
+
+        self.announce("Configuring cmake project", level=3)
+
+        self.spawn(
+            [
+                "cmake",
+                "-S" + ext.cmake_lists_dir,
+                "-B" + self.build_temp,
+                "-DCMAKE_BUILD_TYPE=Release",
+            ]
+        )
+
+        self.announce("Building binaries", level=3)
+
+        self.spawn(
+            ["cmake", "--build", self.build_temp, "--config", "Release", "--parallel", "2" ]
+        )
+
+        # this various depending on the platform so the easiest is to
+        # just check what convention was used
+        if "lib64" in os.listdir(self.build_temp):
+            lib_dir = self.build_temp + "/lib64"
+        else:
+            lib_dir = self.build_temp + "/lib"
+
+        # This is the directory that will make up the final wheel
+        extdir = os.path.dirname(os.path.abspath(self.get_ext_fullpath(ext.name)))
+
+        # copy libopenmc shared library into the python sources
+        # this is where the openmc/lib/__init__.py expects it.
+        shutil.copy(lib_dir + f"/libopenmc.{suffix}", extdir + "/openmc/lib/")
+
+        # copy the binary to a place where the launcher script can find it
+        # and auditwheel is able to properly make it relocatable
+        openmc_exe = self.build_temp + "/bin/openmc"
+        # Note that we can't directly put the binary in the scripts folder,
+        # as auditwheel doesn't handle that case correctly see:
+        # https://github.com/pypa/auditwheel/issues/340
+        shutil.copy(openmc_exe, extdir + "/openmc/openmc_binary")
+
 
 # Get version information from __init__.py. This is ugly, but more reliable than
 # using an import.
-with open('openmc/__init__.py', 'r') as f:
+with open("openmc/__init__.py", "r") as f:
     version = f.readlines()[-1].split()[-1].strip("'")
 
 kwargs = {
-    'name': 'openmc',
-    'version': version,
-    'packages': find_packages(exclude=['tests*']),
-    'scripts': glob.glob('scripts/openmc-*'),
-
+    "name": "openmc",
+    "version": version,
+    "packages": find_packages(exclude=["tests*"]),
+    "scripts": glob.glob("scripts/openmc*"),
     # Data files and libraries
-    'package_data': {
-        'openmc.lib': ['libopenmc.{}'.format(suffix)],
-        'openmc.data': ['mass_1.mas20.txt', 'BREMX.DAT', 'half_life.json', '*.h5'],
-        'openmc.data.effective_dose': ['*.txt']
+    "package_data": {
+        "openmc.data": ["mass_1.mas20.txt", "BREMX.DAT", "half_life.json", "*.h5"],
+        "openmc.data.effective_dose": ["*.txt"],
     },
-
     # Metadata
-    'author': 'The OpenMC Development Team',
-    'author_email': 'openmc@anl.gov',
-    'description': 'OpenMC',
-    'url': 'https://openmc.org',
-    'download_url': 'https://github.com/openmc-dev/openmc/releases',
-    'project_urls': {
-        'Issue Tracker': 'https://github.com/openmc-dev/openmc/issues',
-        'Documentation': 'https://docs.openmc.org',
-        'Source Code': 'https://github.com/openmc-dev/openmc',
+    "author": "The OpenMC Development Team",
+    "author_email": "openmc@anl.gov",
+    "description": "OpenMC",
+    "url": "https://openmc.org",
+    "download_url": "https://github.com/openmc-dev/openmc/releases",
+    "project_urls": {
+        "Issue Tracker": "https://github.com/openmc-dev/openmc/issues",
+        "Documentation": "https://docs.openmc.org",
+        "Source Code": "https://github.com/openmc-dev/openmc",
     },
-    'classifiers': [
-        'Development Status :: 4 - Beta',
-        'Intended Audience :: Developers',
-        'Intended Audience :: End Users/Desktop',
-        'Intended Audience :: Science/Research',
-        'License :: OSI Approved :: MIT License',
-        'Natural Language :: English',
-        'Topic :: Scientific/Engineering'
-        'Programming Language :: C++',
-        'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.7',
-        'Programming Language :: Python :: 3.7',
-        'Programming Language :: Python :: 3.8',
-        'Programming Language :: Python :: 3.9',
-        'Programming Language :: Python :: 3.10',
+    "classifiers": [
+        "Development Status :: 4 - Beta",
+        "Intended Audience :: Developers",
+        "Intended Audience :: End Users/Desktop",
+        "Intended Audience :: Science/Research",
+        "License :: OSI Approved :: MIT License",
+        "Natural Language :: English",
+        "Topic :: Scientific/Engineering" "Programming Language :: C++",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
     ],
-
     # Dependencies
-    'python_requires': '>=3.7',
-    'install_requires': [
-        'numpy>=1.9', 'h5py', 'scipy', 'ipython', 'matplotlib',
-        'pandas', 'lxml', 'uncertainties'
+    "python_requires": ">=3.7",
+    "install_requires": [
+        "numpy>=1.9",
+        "h5py",
+        "scipy",
+        "ipython",
+        "matplotlib",
+        "pandas",
+        "lxml",
+        "uncertainties",
     ],
-    'extras_require': {
-        'depletion-mpi': ['mpi4py'],
-        'docs': ['sphinx', 'sphinxcontrib-katex', 'sphinx-numfig', 'jupyter',
-                 'sphinxcontrib-svg2pdfconverter', 'sphinx-rtd-theme'],
-        'test': ['pytest', 'pytest-cov', 'colorama'],
-        'vtk': ['vtk'],
+    "extras_require": {
+        "depletion-mpi": ["mpi4py"],
+        "docs": [
+            "sphinx",
+            "sphinxcontrib-katex",
+            "sphinx-numfig",
+            "jupyter",
+            "sphinxcontrib-svg2pdfconverter",
+            "sphinx-rtd-theme",
+        ],
+        "test": ["pytest", "pytest-cov", "colorama"],
+        "vtk": ["vtk"],
     },
     # Cython is used to add resonance reconstruction and fast float_endf
-    'ext_modules': cythonize('openmc/data/*.pyx'),
-    'include_dirs': [np.get_include()]
+    "ext_modules": cythonize("openmc/data/*.pyx") + [OpenMCExtension("libopenmc")],
+    "cmdclass": {
+        "build_ext": OpenMCBuildExt,
+    },
+    "include_dirs": [np.get_include()],
 }
 
 setup(**kwargs)

--- a/tools/ci/gha-install.sh
+++ b/tools/ci/gha-install.sh
@@ -45,10 +45,10 @@ if [[ $MPI == 'y' ]]; then
 fi
 
 # Build and install OpenMC executable
-python tools/ci/gha-install.py
+# python tools/ci/gha-install.py
 
 # Install Python API in editable mode
-pip install -e .[test,vtk]
+pip install .[test,vtk]
 
 # For coverage testing of the C++ source files
 pip install cpp-coveralls


### PR DESCRIPTION
@shimwell If you have some time to look at this I'd love your opinion on this. 

I kept running into issues when relocating the built `openmc` binary and `scikit-build` wasn't really helping.   
So I tried to get a minimal working example with just setuptools. 

This PR now implements the build just using `setuptools` and is still pretty minimal. Not sure that `scikit-build` is really needed.  

The relocatability problem turned out to be that one can't place a binary into the python scripts folder if that binary needs an `rpath` that points to the libraries in the `platlib` folders of the python package. 
(See https://github.com/pypa/auditwheel/issues/340) 

Solution is that the binary goes into the `platlib` folder as well, and we drop a python script into the scripts folder which can then simply forwards the calls to the binary. 

